### PR TITLE
clang-tidy: ignore third-party code nlohmann/json.h

### DIFF
--- a/src/rpc/nlohmann/.clang-tidy
+++ b/src/rpc/nlohmann/.clang-tidy
@@ -1,0 +1,2 @@
+# third-party library, disable all checks in this folder.
+Checks: '-*'


### PR DESCRIPTION
suggestion from the peanut gallery to cut down on errors in your json-rpc diff